### PR TITLE
Bugfix/directory

### DIFF
--- a/qt/app/mainwindow.cpp
+++ b/qt/app/mainwindow.cpp
@@ -49,17 +49,6 @@ void MainWindow::on_pushButton_pages_view_clicked()
 
     void MainWindow::on_comboBox_list_type_activated(int index)
     {
-        clearButtons();
-        if (index == 0)
-        {
-            ui->comboBox_list_sort->addItems(sortTeams);
-            ui->comboBox_list_filter->addItems(filterTeams);
-        }
-        else
-        {
-            ui->comboBox_list_sort->addItems(sortStadiums);
-            ui->comboBox_list_filter->addItems(filterStadiums);
-        }
 
     }
 
@@ -139,6 +128,8 @@ void MainWindow::initializeLayout() // sets default pages on program restart
     on_pushButton_pages_home_clicked();
     on_comboBox_edit_activated(0);
     ui->pushButton_pages_home->setDisabled(true);
+    ui->comboBox_list_sort->addItems(sortTable); // directory page
+    ui->comboBox_list_filter->addItems(filterTable);
 }
 void MainWindow::clearButtons() // resets most program states
 {
@@ -148,9 +139,9 @@ void MainWindow::clearButtons() // resets most program states
     ui->pushButton_pages_plan->setDisabled(false);
     ui->pushButton_pages_admin->setDisabled(false);
 
-    // view combo boxes
-    ui->comboBox_list_sort->clear();
-    ui->comboBox_list_filter->clear();
+    // view page
+    ui->comboBox_list_sort->setCurrentIndex(0);
+    ui->comboBox_list_filter->setCurrentIndex(0);
 
     // trip planning buttons
     ui->pushButton_plan_sort->setVisible(false);
@@ -163,7 +154,6 @@ void MainWindow::clearButtons() // resets most program states
     ui->pushButton_plan_vikings->setDisabled(false);
     ui->pushButton_plan_custom->setDisabled(false);
     ui->pushButton_plan_MST->setDisabled(false);
-
 
     // admin buttons
     ui->formWidget_edit_souvenir->setDisabled(true);

--- a/qt/app/mainwindow.cpp
+++ b/qt/app/mainwindow.cpp
@@ -44,12 +44,6 @@ void MainWindow::on_pushButton_pages_view_clicked()
         ui->stackedWidget_view_pages->setCurrentIndex(LIST);
         ui->pushButton_view_search->setDisabled(false);
         ui->pushButton_view_list->setDisabled(true);
-        on_comboBox_list_type_activated(0);
-    }
-
-    void MainWindow::on_comboBox_list_type_activated(int index)
-    {
-
     }
 
 void MainWindow::on_pushButton_pages_plan_clicked()
@@ -128,8 +122,10 @@ void MainWindow::initializeLayout() // sets default pages on program restart
     on_pushButton_pages_home_clicked();
     on_comboBox_edit_activated(0);
     ui->pushButton_pages_home->setDisabled(true);
-    ui->comboBox_list_sort->addItems(sortTable); // directory page
-    ui->comboBox_list_filter->addItems(filterTable);
+    ui->comboBox_list_sortteams->addItems(sortTeams); // directory page
+    ui->comboBox_list_filterteams->addItems(filterTeams);
+    ui->comboBox_list_sortstadiums->addItems(sortStadiums);
+    ui->comboBox_list_filterstadiums->addItems(filterStadiums);
 }
 void MainWindow::clearButtons() // resets most program states
 {
@@ -140,8 +136,10 @@ void MainWindow::clearButtons() // resets most program states
     ui->pushButton_pages_admin->setDisabled(false);
 
     // view page
-    ui->comboBox_list_sort->setCurrentIndex(0);
-    ui->comboBox_list_filter->setCurrentIndex(0);
+    ui->comboBox_list_sortteams->setCurrentIndex(0);
+    ui->comboBox_list_filterteams->setCurrentIndex(0);
+    ui->comboBox_list_sortstadiums->setCurrentIndex(0);
+    ui->comboBox_list_filterstadiums->setCurrentIndex(0);
 
     // trip planning buttons
     ui->pushButton_plan_sort->setVisible(false);
@@ -175,6 +173,13 @@ void MainWindow::clearButtons() // resets most program states
     ui->LineEdit_edit_stadium_name->clear();
     ui->LineEdit_edit_stadium_roof->clear();
     ui->LineEdit_edit_stadium_surface->clear();
+}
+
+void MainWindow::clearViewLabels()
+{
+    ui->label_list_totalcapacity->hide();
+    ui->label_list_totalgrass->hide();
+    ui->label_list_totalroofs->hide();
 }
 
 void MainWindow::on_pushButton_edit_add_clicked() // admin add button

--- a/qt/app/mainwindow.cpp
+++ b/qt/app/mainwindow.cpp
@@ -136,10 +136,12 @@ void MainWindow::clearButtons() // resets most program states
     ui->pushButton_pages_admin->setDisabled(false);
 
     // view page
-    ui->comboBox_list_sortteams->setCurrentIndex(0);
-    ui->comboBox_list_filterteams->setCurrentIndex(0);
-    ui->comboBox_list_sortstadiums->setCurrentIndex(0);
-    ui->comboBox_list_filterstadiums->setCurrentIndex(0);
+    ui->comboBox_list_sortteams->setCurrentIndex(NOTEAMSORT);
+    ui->comboBox_list_filterteams->setCurrentIndex(ALLTEAMS);
+    ui->comboBox_list_sortstadiums->setCurrentIndex(NOSTADIUMSORT);
+    ui->comboBox_list_filterstadiums->setCurrentIndex(ALLSTADIUMS);
+    clearViewLabels();
+
 
     // trip planning buttons
     ui->pushButton_plan_sort->setVisible(false);

--- a/qt/app/mainwindow.h
+++ b/qt/app/mainwindow.h
@@ -27,8 +27,6 @@ private slots:
 
         void on_pushButton_view_list_clicked();
 
-        void on_comboBox_list_type_activated(int index);
-
     void on_pushButton_pages_plan_clicked();
 
         void on_pushButton_plan_continue_clicked();
@@ -54,6 +52,8 @@ private slots:
     void initializeLayout();
 
     void clearButtons();
+
+    void clearViewLabels();
 
     void on_pushButton_edit_add_clicked();
 
@@ -101,8 +101,10 @@ private:
     /*----END NAVIGATION ENUMS----*/
 
     /*----DIRECTORY COMBO BOXES----*/
-    QStringList sortTable = { "Team Name","Stadium Name", "Conference Name", "Date Opened", "Capacity" };
-    QStringList filterTable = { "All", "AFC", "NFC", "NFC North", "Bermuda Grass", "Open Roof" };
+    QStringList sortTeams = { "None", "Team Name", "Conference Name" };
+    QStringList sortStadiums = { "None", "Stadium Name", "Date Opened", "Capacity" };
+    QStringList filterTeams = { "All", "AFC", "NFC", "NFC North", "Bermuda Grass" };
+    QStringList filterStadiums = { "All", "Open Roof" };
     /*----END DIRECTORY COMBO BOXES----*/
 
 	Ui::MainWindow *ui;

--- a/qt/app/mainwindow.h
+++ b/qt/app/mainwindow.h
@@ -98,6 +98,37 @@ private:
         IMPORT,
         EDIT
     };
+
+    enum SortTeams
+    {
+        NOTEAMSORT,
+        TEAMNAME,
+        CONFERENCENAME
+    };
+
+    enum SortStadiums
+    {
+        NOSTADIUMSORT,
+        STADIUMNAME,
+        DATEOPENED,
+        CAPACITY
+    };
+
+    enum FilterTeams
+    {
+        ALLTEAMS,
+        AFC,
+        NFC,
+        NFCNORTH,
+        BERMUDAGRASS
+    };
+
+    enum FilterStadiums
+    {
+        ALLSTADIUMS,
+        OPENROOF
+    };
+
     /*----END NAVIGATION ENUMS----*/
 
     /*----DIRECTORY COMBO BOXES----*/

--- a/qt/app/mainwindow.h
+++ b/qt/app/mainwindow.h
@@ -101,10 +101,8 @@ private:
     /*----END NAVIGATION ENUMS----*/
 
     /*----DIRECTORY COMBO BOXES----*/
-    QStringList sortTeams = { "Team Name", "Conference Name" };
-    QStringList filterTeams = { "All", "AFC", "NFC", "NFC North", "Bermuda Grass" };
-    QStringList sortStadiums = { "Stadium Name", "Date Opened", "Capacity" };
-    QStringList filterStadiums = { "All", "Open Roof" };
+    QStringList sortTable = { "Team Name","Stadium Name", "Conference Name", "Date Opened", "Capacity" };
+    QStringList filterTable = { "All", "AFC", "NFC", "NFC North", "Bermuda Grass", "Open Roof" };
     /*----END DIRECTORY COMBO BOXES----*/
 
 	Ui::MainWindow *ui;

--- a/qt/app/mainwindow.ui
+++ b/qt/app/mainwindow.ui
@@ -327,19 +327,13 @@
            <layout class="QGridLayout" name="gridLayout_list_2">
             <item row="0" column="0">
              <layout class="QGridLayout" name="gridLayout_list">
-              <item row="2" column="0" colspan="4">
-               <widget class="QLabel" name="label_list_total">
-                <property name="font">
-                 <font>
-                  <pointsize>12</pointsize>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Total &quot;______&quot;: </string>
-                </property>
-               </widget>
+              <item row="1" column="0" colspan="4">
+               <widget class="QTableView" name="tableView_list"/>
               </item>
-              <item row="0" column="3">
+              <item row="1" column="0" colspan="6">
+               <widget class="QTableView" name="tableView_list"/>
+              </item>
+              <item row="0" column="5">
                <widget class="QComboBox" name="comboBox_list_filter">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -354,10 +348,7 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="0" colspan="4">
-               <widget class="QTableView" name="tableView_list"/>
-              </item>
-              <item row="0" column="2">
+              <item row="0" column="4">
                <widget class="QComboBox" name="comboBox_list_sort">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -372,10 +363,19 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="0" colspan="6">
-               <widget class="QTableView" name="tableView_list"/>
+              <item row="2" column="2" colspan="2">
+               <widget class="QLabel" name="label_list_total">
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Total Bermuda Grass Stadiums: </string>
+                </property>
+               </widget>
               </item>
-              <item row="2" column="2" colspan="4">
+              <item row="2" column="4">
                <widget class="QLabel" name="label_list_totalcapacity">
                 <property name="font">
                  <font>
@@ -387,7 +387,7 @@
                 </property>
                </widget>
               </item>
-              <item row="2" column="0" colspan="2">
+              <item row="2" column="0">
                <widget class="QLabel" name="label_list_totalroofs">
                 <property name="font">
                  <font>

--- a/qt/app/mainwindow.ui
+++ b/qt/app/mainwindow.ui
@@ -364,7 +364,7 @@
                </widget>
               </item>
               <item row="2" column="2" colspan="2">
-               <widget class="QLabel" name="label_list_total">
+               <widget class="QLabel" name="label_list_totalgrass">
                 <property name="font">
                  <font>
                   <pointsize>12</pointsize>
@@ -375,19 +375,7 @@
                 </property>
                </widget>
               </item>
-              <item row="2" column="4">
-               <widget class="QLabel" name="label_list_totalcapacity">
-                <property name="font">
-                 <font>
-                  <pointsize>12</pointsize>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Total Capacity: </string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
+              <item row="2" column="0" colspan="2">
                <widget class="QLabel" name="label_list_totalroofs">
                 <property name="font">
                  <font>
@@ -396,6 +384,18 @@
                 </property>
                 <property name="text">
                  <string>Total Open Roof Stadiums: </string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="4" colspan="2">
+               <widget class="QLabel" name="label_list_totalcapacity">
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Total Capacity: </string>
                 </property>
                </widget>
               </item>

--- a/qt/app/mainwindow.ui
+++ b/qt/app/mainwindow.ui
@@ -327,8 +327,44 @@
            <layout class="QGridLayout" name="gridLayout_list_2">
             <item row="0" column="0">
              <layout class="QGridLayout" name="gridLayout_list">
-              <item row="0" column="5">
+              <item row="0" column="2">
+               <widget class="QComboBox" name="comboBox_list_sortstadiums">
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0" alignment="Qt::AlignRight">
+               <widget class="QLabel" name="label_list_sort">
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Sort:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="6">
                <widget class="QComboBox" name="comboBox_list_filterstadiums">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="5">
+               <widget class="QComboBox" name="comboBox_list_filterteams">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                   <horstretch>0</horstretch>
@@ -357,7 +393,16 @@
                 </property>
                </widget>
               </item>
-              <item row="2" column="4" colspan="2">
+              <item row="0" column="1">
+               <widget class="QComboBox" name="comboBox_list_sortteams">
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="5" colspan="2">
                <widget class="QLabel" name="label_list_totalcapacity">
                 <property name="font">
                  <font>
@@ -381,51 +426,6 @@
                 </property>
                </widget>
               </item>
-              <item row="0" column="4">
-               <widget class="QComboBox" name="comboBox_list_filterteams">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="font">
-                 <font>
-                  <pointsize>12</pointsize>
-                 </font>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QComboBox" name="comboBox_list_sortteams">
-                <property name="font">
-                 <font>
-                  <pointsize>12</pointsize>
-                 </font>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <widget class="QComboBox" name="comboBox_list_sortstadiums">
-                <property name="font">
-                 <font>
-                  <pointsize>12</pointsize>
-                 </font>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0" alignment="Qt::AlignRight">
-               <widget class="QLabel" name="label_list_sort">
-                <property name="font">
-                 <font>
-                  <pointsize>12</pointsize>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Sort:</string>
-                </property>
-               </widget>
-              </item>
               <item row="0" column="3" alignment="Qt::AlignRight">
                <widget class="QLabel" name="label_list_filter">
                 <property name="font">
@@ -438,7 +438,20 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="0" colspan="6">
+              <item row="2" column="4">
+               <widget class="QLabel" name="label_list_invisiblespacer">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0" colspan="7">
                <widget class="QTableView" name="tableView_list"/>
               </item>
              </layout>

--- a/qt/app/mainwindow.ui
+++ b/qt/app/mainwindow.ui
@@ -327,53 +327,23 @@
            <layout class="QGridLayout" name="gridLayout_list_2">
             <item row="0" column="0">
              <layout class="QGridLayout" name="gridLayout_list">
+              <item row="0" column="5">
+               <widget class="QComboBox" name="comboBox_list_filterstadiums">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
               <item row="1" column="0" colspan="4">
                <widget class="QTableView" name="tableView_list"/>
-              </item>
-              <item row="1" column="0" colspan="6">
-               <widget class="QTableView" name="tableView_list"/>
-              </item>
-              <item row="0" column="5">
-               <widget class="QComboBox" name="comboBox_list_filter">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="font">
-                 <font>
-                  <pointsize>12</pointsize>
-                 </font>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="4">
-               <widget class="QComboBox" name="comboBox_list_sort">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="font">
-                 <font>
-                  <pointsize>12</pointsize>
-                 </font>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="2" colspan="2">
-               <widget class="QLabel" name="label_list_totalgrass">
-                <property name="font">
-                 <font>
-                  <pointsize>12</pointsize>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Total Bermuda Grass Stadiums: </string>
-                </property>
-               </widget>
               </item>
               <item row="2" column="0" colspan="2">
                <widget class="QLabel" name="label_list_totalroofs">
@@ -398,6 +368,78 @@
                  <string>Total Capacity: </string>
                 </property>
                </widget>
+              </item>
+              <item row="2" column="2" colspan="2">
+               <widget class="QLabel" name="label_list_totalgrass">
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Total Bermuda Grass Stadiums: </string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="4">
+               <widget class="QComboBox" name="comboBox_list_filterteams">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QComboBox" name="comboBox_list_sortteams">
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="QComboBox" name="comboBox_list_sortstadiums">
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0" alignment="Qt::AlignRight">
+               <widget class="QLabel" name="label_list_sort">
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Sort:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="3" alignment="Qt::AlignRight">
+               <widget class="QLabel" name="label_list_filter">
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Filter:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0" colspan="6">
+               <widget class="QTableView" name="tableView_list"/>
               </item>
              </layout>
             </item>

--- a/qt/app/mainwindow.ui
+++ b/qt/app/mainwindow.ui
@@ -327,27 +327,19 @@
            <layout class="QGridLayout" name="gridLayout_list_2">
             <item row="0" column="0">
              <layout class="QGridLayout" name="gridLayout_list">
-              <item row="0" column="4">
-               <widget class="QComboBox" name="comboBox_list_sort">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
+              <item row="2" column="0" colspan="4">
+               <widget class="QLabel" name="label_list_total">
                 <property name="font">
                  <font>
                   <pointsize>12</pointsize>
                  </font>
                 </property>
-                <item>
-                 <property name="text">
-                  <string>SORT</string>
-                 </property>
-                </item>
+                <property name="text">
+                 <string>Total &quot;______&quot;: </string>
+                </property>
                </widget>
               </item>
-              <item row="0" column="5">
+              <item row="0" column="3">
                <widget class="QComboBox" name="comboBox_list_filter">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -360,15 +352,13 @@
                   <pointsize>12</pointsize>
                  </font>
                 </property>
-                <item>
-                 <property name="text">
-                  <string>FILTER</string>
-                 </property>
-                </item>
                </widget>
               </item>
-              <item row="0" column="3">
-               <widget class="QComboBox" name="comboBox_list_type">
+              <item row="1" column="0" colspan="4">
+               <widget class="QTableView" name="tableView_list"/>
+              </item>
+              <item row="0" column="2">
+               <widget class="QComboBox" name="comboBox_list_sort">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                   <horstretch>0</horstretch>
@@ -380,16 +370,6 @@
                   <pointsize>12</pointsize>
                  </font>
                 </property>
-                <item>
-                 <property name="text">
-                  <string>Teams</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Stadiums</string>
-                 </property>
-                </item>
                </widget>
               </item>
               <item row="1" column="0" colspan="6">


### PR DESCRIPTION
removed a combo box: now only sort and filter
changed qstringlists to reflect changes (some indices might be different now)
renamed qstringlists to sortTable and filterTable 
removed all layout logic from "on_comboBox_list_type_activated(int index)"
only view page logic on "clearButtons()" now is setCurrentIndex(0) for both combo boxes
combo boxes now populated on program startup

label_list_totalgrass