### PR TITLE
update buttons and set tableview to noEditTrigger

### DIFF
--- a/qt/app/mainwindow.cpp
+++ b/qt/app/mainwindow.cpp
@@ -97,6 +97,8 @@ void MainWindow::on_pushButton_pages_plan_clicked()
 
     void MainWindow::on_pushButton_plan_continue_clicked()
     {
+        if(selectedTeams.size() < 2)
+            return;
         ui->stackedWidget_pages->setCurrentIndex(POS);
         QVector<Souvenir> tempCart;
         DBManager::instance()->CreateShoppingList(selectedTeams,tempCart);
@@ -116,6 +118,11 @@ void MainWindow::on_pushButton_pages_plan_clicked()
             connect(table->purchaseTableSpinBoxes->at(i), SIGNAL(valueChanged(int)), this, SLOT(updateCartTotal()));
         }
         ui->label_pos_distance->setText(ui->label_plan_distance->text());
+
+        for (int i = 0; i < tempCart.size(); i++)
+        {
+            souvenirList.insert({tempCart[i].teamID, tempCart[i]});
+        }
     }
 
     void MainWindow::on_pushButton_pos_cancel_clicked()
@@ -656,9 +663,6 @@ void MainWindow::on_pushButton_plan_custom_clicked()
     table->showTeamNames(ui->tableView_plan_custom);
     table->showTeams(ui->tableView_plan_route,selectedTeams);
 
-    // planning logic
-
-    ui->pushButton_plan_continue->setDisabled(false);
 }
 
 /*----END HELPER FUNCTIONS----*/
@@ -883,6 +887,11 @@ void MainWindow::on_pushButton_plan_add_clicked()
     }
     table->showTeams(ui->tableView_plan_custom, availableTeams);
     table->showTeams(ui->tableView_plan_route, selectedTeams);
+
+    if(selectedTeams.size() < 2)
+        ui->pushButton_plan_continue->setDisabled(true);
+    else
+        ui->pushButton_plan_continue->setDisabled(false);
 }
 
 void MainWindow::on_pushButton_plan_remove_clicked()
@@ -896,6 +905,7 @@ void MainWindow::on_pushButton_plan_remove_clicked()
         DBManager::instance()->GetTeams(availableTeams);
         availableTeams.removeAll("Green Bay Packers");
         ui->pushButton_plan_add->setDisabled(false);
+        ui->label_plan_distance->setText("Trip Distance: ");
     }
     if (ui->tableView_plan_route->currentIndex().row() >= 0 && ui->tableView_plan_route->currentIndex().row() < availableTeams.size())
     {
@@ -908,6 +918,10 @@ void MainWindow::on_pushButton_plan_remove_clicked()
 //    ui->label_plan_distance->setText("Trip Distance: ");
     table->showTeams(ui->tableView_plan_custom, availableTeams);
     table->showTeams(ui->tableView_plan_route, selectedTeams);
+
+    if(selectedTeams.size() < 2)
+        ui->pushButton_plan_continue->setDisabled(true);
+
 }
 
 void MainWindow::updateCartTotal()

--- a/qt/app/mainwindow.cpp
+++ b/qt/app/mainwindow.cpp
@@ -117,7 +117,6 @@ void MainWindow::on_pushButton_pages_plan_clicked()
         {
             connect(table->purchaseTableSpinBoxes->at(i), SIGNAL(valueChanged(int)), this, SLOT(updateCartTotal()));
         }
-        ui->label_pos_distance->setText(ui->label_plan_distance->text());
 
         for (int i = 0; i < tempCart.size(); i++)
         {

--- a/qt/app/mainwindow.h
+++ b/qt/app/mainwindow.h
@@ -6,6 +6,7 @@
 #include <QLabel>
 #include "dbmanager.h"
 #include <bfs.h>
+#include "unordered_map.h"
 
 QT_BEGIN_NAMESPACE
 namespace Ui { class MainWindow; }
@@ -205,5 +206,8 @@ private:
 
     QStringList availableTeams;
     QStringList selectedTeams;
+
+    nonstd::unordered_map<int,Souvenir> souvenirList;
 };
+
 #endif // MAINWINDOW_H

--- a/qt/app/tablemanager.cpp
+++ b/qt/app/tablemanager.cpp
@@ -217,6 +217,7 @@ void TableManager::showTeams(QTableView* table, QStringList& available)
 
     table->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
     table->verticalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+    table->setEditTriggers(QTableView::NoEditTriggers);
     table->setModel(model);
 }
 


### PR DESCRIPTION
If there are less than 2 teams selected -> continue is disabled
table views for plan trips are set to noEditTrigger
reset distance for green bay trip after select remove
add in dummy variable for unordered_map